### PR TITLE
feat: add minimum supported rust version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,6 +13,7 @@ jobs:
           - macOS-latest
         rust:
           - 1.70.0
+          - stable
           - beta
           - nightly
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ jobs:
           - ubuntu-latest
           - macOS-latest
         rust:
-          - stable
+          - 1.70.0
           - beta
           - nightly
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ description = "Asynchronous ICMP pinging library"
 keywords = ["tokio", "icmp", "ping"]
 categories = ["network-programming", "asynchronous"]
 edition = "2021"
+rust-version = "1.70.0"
 
 [dependencies]
 futures = "0.3"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 tokio-icmp-echo is an asynchronous ICMP pinging library. It was originally written by Fedor Gogolev, a.k.a. knsd, and distributed under the name tokio-ping. This here is a fork that includes mostly maintenance work, to make sure it works in the current state of the async rust ecosystem.
 
+The minimum supported rust version is `1.70.0`
+
 # Usage example
 
 Note, sending and receiving ICMP packets requires privileges.


### PR DESCRIPTION
There isn't a place that mentions the MSRV, using [cargo-msrv](https://crates.io/crates/cargo-msrv) it mentions it is `1.70.0` (because of tokio).
This PR also adds this version in the CI.