### PR TITLE
ci: add clippy and docs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,6 +36,9 @@ jobs:
         with:
           command: test
 
+      - name: Install clippy component
+        run: rustup component add clippy --toolchain ${{ matrix.rust }}
+
       - name: Run cargo clippy
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,3 +35,16 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings
+
+      - name: Run cargo docs
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+        env:
+          RUSTDOCFLAGS: "-D warnings"


### PR DESCRIPTION
Follow up from #4.
This PR adds clippy and docs checks (and fails on warnings).