### PR TITLE
deps: update socket2 to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.70.0"
 futures = "0.3"
 mio = { version = "1.0", features = ["os-ext"] }
 rand = "0.9"
-socket2 = { version = "0.5", features = ["all"] }
+socket2 = { version = "0.6", features = ["all"] }
 tokio = { version = "1", features = ["rt", "time", "net"] }
 parking_lot = "0.12"
 thiserror = "2"


### PR DESCRIPTION
Fortunately no breaking changes for the project, libs are starting to migrate to it so I'd say to update it.
I'd be grateful if a release can be done after the merge of this PR.